### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM python:3.6.2-alpine3.6
+FROM python:3.6.4-alpine3.7
 
 RUN \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     apk add --no-cache \
         bash \
         ca-certificates \
         g++ \
         git \
-        librdkafka@edge \
-        librdkafka-dev@edge \
+        librdkafka \
+        librdkafka-dev \
         libressl \
         libressl-dev \
         linux-headers \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=python-alpine-kafka
-TAG=latest
+TAG=python3.6.4-librdkafka0.11.1-r1
 
 build:
 	docker build -t $(REPO)/$(NAME):$(TAG) .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Cython==0.25.2
 confluent-kafka[avro]==0.11.0
-fastavro==0.16.3
+fastavro==0.16.7


### PR DESCRIPTION
Right now we use install librdkafka 0.9.5 (we want 0.11.1) because of some "bug" in Alpine. Instead let's upgrade to latest stable versions instead where everything seems to work. This will hopefully solve the performance issues we are having atm.

Lets also start using proper docker tags (thanks @saabeilin), this one will be tagged `python3.6.4-librdkafka0.11.1-r1` and the current one will get an additional tag `python3.6.2-librdkafka0.9.5-r0`.