### PR TITLE
Use debian as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,5 @@
-FROM debian:buster-slim AS builder
-WORKDIR /tmp
-ARG LIBRDKAFKA_VERSION=1.3.0
-RUN apt-get update && apt-get install -y curl build-essential && \
-    curl -Lo librdkafka-$LIBRDKAFKA_VERSION.tar.gz https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VERSION.tar.gz && \
-    tar zxf librdkafka-$LIBRDKAFKA_VERSION.tar.gz && \
-    cd librdkafka-$LIBRDKAFKA_VERSION && \
-    ./configure --install-deps && \
-    make && \
-    make install
-
 FROM python:3.8-slim-buster
-COPY --from=builder /usr/local/lib/librdkafka* /usr/local/lib/
-COPY --from=builder /usr/local/include/librdkafka/ /usr/local/include/librdkafka/
-RUN apt-get update && apt-get install -y sudo libsasl2-2 && ldconfig && \
+RUN apt-get update && apt-get install -y sudo && \
     echo "app ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/app && \
     useradd -d /app --create-home app && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,13 @@ RUN apt-get update && apt-get install -y curl build-essential && \
 FROM python:3.8-slim-buster
 COPY --from=librdkafka /usr/local/lib/librdkafka* /usr/local/lib/
 COPY --from=librdkafka /usr/local/include/librdkafka/ /usr/local/include/librdkafka/
-RUN apt-get update && apt-get install -y libsasl2-2 && ldconfig
+RUN apt-get update && apt-get install -y sudo libsasl2-2 && ldconfig && \
+    echo "app ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/app && \
+    useradd -d /app --create-home app && \
+    rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
+WORKDIR /app
+USER app
 ENV PYTHONUNBUFFERED 1
 CMD ["python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,19 @@
-FROM python:3.7.6-alpine3.10
-
-RUN apk add --no-cache \
-        bash \
-        ca-certificates \
-        g++ \
-        gcc \
-        git \
-        libressl \
-        libressl-dev \
-        linux-headers \
-        make \
-        musl-dev \
-        zlib-dev
-
-ARG LIBRDKAFKA_VERSION=1.0.1
-RUN wget https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VERSION.tar.gz \
-        -O /tmp/librdkafka-$LIBRDKAFKA_VERSION.tar.gz && \
-    cd /tmp/ && \
+FROM debian:buster-slim AS librdkafka
+WORKDIR /tmp
+ARG LIBRDKAFKA_VERSION=1.3.0
+RUN apt-get update && apt-get install -y curl build-essential && \
+    curl -Lo librdkafka-$LIBRDKAFKA_VERSION.tar.gz https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VERSION.tar.gz && \
     tar zxf librdkafka-$LIBRDKAFKA_VERSION.tar.gz && \
     cd librdkafka-$LIBRDKAFKA_VERSION && \
-    ./configure && \
+    ./configure --install-deps && \
     make && \
-    make install && \
-    cd .. && rm -fr librdkafka-$LIBRDKAFKA_VERSION
+    make install
 
+FROM python:3.8-slim-buster
+COPY --from=librdkafka /usr/local/lib/librdkafka* /usr/local/lib/
+COPY --from=librdkafka /usr/local/include/librdkafka/ /usr/local/include/librdkafka/
+RUN apt-get update && apt-get install -y libsasl2-2 && ldconfig
 COPY requirements.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
-
 ENV PYTHONUNBUFFERED 1
 CMD ["python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS librdkafka
+FROM debian:buster-slim AS builder
 WORKDIR /tmp
 ARG LIBRDKAFKA_VERSION=1.3.0
 RUN apt-get update && apt-get install -y curl build-essential && \
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y curl build-essential && \
     make install
 
 FROM python:3.8-slim-buster
-COPY --from=librdkafka /usr/local/lib/librdkafka* /usr/local/lib/
-COPY --from=librdkafka /usr/local/include/librdkafka/ /usr/local/include/librdkafka/
+COPY --from=builder /usr/local/lib/librdkafka* /usr/local/lib/
+COPY --from=builder /usr/local/include/librdkafka/ /usr/local/include/librdkafka/
 RUN apt-get update && apt-get install -y sudo libsasl2-2 && ldconfig && \
     echo "app ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/app && \
     useradd -d /app --create-home app && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim-buster
-RUN apt-get update && apt-get install -y sudo && \
-    echo "app ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/app && \
+RUN apt update && apt install -y sudo && \
+    echo "app ALL=(ALL) NOPASSWD:/usr/bin/apt" > /etc/sudoers.d/app && \
     useradd -d /app --create-home app && \
     rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=python-confluent-kafka
-TAG=python3.8-buster-confluent-kafka1.3.0-v0
+TAG=1.3.0-python3.8-buster-v0
 IMAGE=$(REPO)/$(NAME):$(TAG)
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=python-alpine-kafka
-TAG=python3.8-buster-librdkafka1.3.0-v0
+TAG=python3.8-buster-confluent-kafka1.3.0-v0
 IMAGE=$(REPO)/$(NAME):$(TAG)
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=python-alpine-kafka
-TAG=python3.7.6-librdkafka1.0.1-v0
+TAG=python3.8-buster-librdkafka1.3.0-v0
 IMAGE=$(REPO)/$(NAME):$(TAG)
 
 build:
@@ -8,7 +8,7 @@ build:
 	docker tag $(IMAGE) $(REPO)/$(NAME):latest
 
 run:
-	docker run -it --rm $(IMAGE)
+	docker run -it --rm $(IMAGE) bash
 
 push:
 	docker push $(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO=fyndiq
-NAME=python-alpine-kafka
+NAME=python-confluent-kafka
 TAG=python3.8-buster-confluent-kafka1.3.0-v0
 IMAGE=$(REPO)/$(NAME):$(TAG)
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,1 @@
-avro-python3
-confluent-kafka[avro]
-fastavro
+confluent-kafka[avro]>=1.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Cython==0.29.10
-avro-python3==1.8.2
-confluent-kafka[avro]==1.0.1
-fastavro==0.21.24
+Cython
+avro-python3
+confluent-kafka[avro]
+fastavro

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-Cython
 avro-python3
 confluent-kafka[avro]
 fastavro

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ avro-python3==1.9.2.1
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 confluent-kafka[avro]==1.3.0
-cython==0.29.15
 fastavro==0.22.9
 idna==2.8                 # via requests
 requests==2.22.0          # via confluent-kafka

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-avro-python3==1.8.2
+avro-python3==1.9.2.1
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-confluent-kafka[avro]==1.0.1
-cython==0.29.10
-fastavro==0.21.24
+confluent-kafka[avro]==1.3.0
+cython==0.29.15
+fastavro==0.22.9
 idna==2.8                 # via requests
 requests==2.22.0          # via confluent-kafka
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-avro-python3==1.9.2.1
+avro-python3==1.9.2.1     # via confluent-kafka
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 confluent-kafka[avro]==1.3.0
-fastavro==0.22.9
+fastavro==0.22.9          # via confluent-kafka
 idna==2.8                 # via requests
 requests==2.22.0          # via confluent-kafka
 urllib3==1.25.8           # via requests


### PR DESCRIPTION
## Changes
 - Use Debian as a base image since Alpine doesn't have any pre built wheel packages making build times much longer in the services
 - Install librdkafka from wheels (thanks @saabeilin) instead from source. Only possible with confluent-kafka>=1.3.0
 - Run container as unprivileged user (app) instead of root

## TODO
 - Rename repo to `python-confluent-kafka` (since alpine is not relevant anymore)

## Example service Dockerfile
```dockerfile
FROM fyndiq/python-confluent-kafka:1.3.0-python3.8-buster-v0 AS builder
RUN sudo apt-get update && sudo apt-get install -y git gcc
COPY requirements/* /tmp/
RUN pip install --user --no-cache-dir --upgrade pip && \
    pip install --user --no-cache-dir -r /tmp/common.txt -r /tmp/prod.txt

FROM fyndiq/python-confluent-kafka:1.3.0-python3.8-buster-v0
COPY --from=builder --chown=app:app /app/.local/ /app/.local/
COPY --chown=app:app . /app
CMD ["python", "consumer.py"]
```