### PR TITLE
Tag latest image on the push step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ IMAGE=$(REPO)/$(NAME):$(TAG)
 
 build:
 	docker build -t $(IMAGE) .
-	docker tag $(IMAGE) $(REPO)/$(NAME):latest
 
 run:
 	docker run -it --rm $(IMAGE) bash
 
 push:
+	docker tag $(IMAGE) $(REPO)/$(NAME):latest
 	docker push $(IMAGE)
 	docker push $(REPO)/$(NAME):latest
 


### PR DESCRIPTION
The tag of the latest image should be done on the push stage since we would lose that information between steps.