### PR TITLE
Add deprecation warning that we will no longer mantain this image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Python Confluent Kafka
+
+**This image is deprecated in favor of using python-slim images directly.**
+
 Docker image used as base image for services in quality. Includes Python
 and confluent-kafka dependency.
 


### PR DESCRIPTION
**Background**

This image is no longer adding a lot since we migrated from alpine. We no longer need to build the requirements since wheels are provided.﻿
